### PR TITLE
fixed reauthentication loop and firestore closing

### DIFF
--- a/wayat/frontend/lib/app_state/location_state/location_listener.dart
+++ b/wayat/frontend/lib/app_state/location_state/location_listener.dart
@@ -56,4 +56,12 @@ abstract class _LocationListener with Store {
         onContactsRefUpdate: onContactsRefUpdateCallback,
         onLocationModeUpdate: onLocationModeUpdateCallback);
   }
+
+  /// Closes the listener in [locationListenerService].
+  ///
+  /// This is done to avoid having a listener connection error after doing
+  /// a signOut from Firebase.
+  void closeListener() {
+    locationListenerService.cancelListenerSubscription();
+  }
 }

--- a/wayat/frontend/lib/app_state/user_state/user_state.dart
+++ b/wayat/frontend/lib/app_state/user_state/user_state.dart
@@ -57,6 +57,7 @@ abstract class _UserState with Store {
 
   /// Shows the graphical interface to login an user and
   /// proceeds with the login process.
+  @action
   Future<void> login() async {
     googleAccount = await authService.signIn();
     // googleAccount will be null if the user cancels the google authentication
@@ -68,12 +69,16 @@ abstract class _UserState with Store {
   /// Log out process. This includes closing the map,
   /// undoing changes in the login state and calling the
   /// [authService] [signOut].
+  @action
   Future<void> logOut() async {
     final LifeCycleState lifeCycleState = GetIt.I.get<LifeCycleState>();
     await lifeCycleState.notifyAppClosed();
 
     await authService.signOut();
+    // This needs to be after [signOut] to not navigate to the login page
+    // before doing the sign out completely
     currentUser = null;
+    googleAccount = null;
   }
 
   /// Checks if login process can be done without a

--- a/wayat/frontend/lib/services/authentication/gauth_service_impl.dart
+++ b/wayat/frontend/lib/services/authentication/gauth_service_impl.dart
@@ -1,3 +1,5 @@
+import 'dart:developer';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:get_it/get_it.dart';
@@ -26,6 +28,13 @@ class GoogleAuthService implements AuthService {
 
   /// Service to login in with Google and obtain the user's data and token
   late GoogleSignIn _googleSignIn;
+
+  /// Whether the user has signed out from this account in this current session.
+  ///
+  /// This is necessary because the method [signInSilently] can reAuthenticate
+  /// even with the argument reAuthenticate to `true` (which is in fact, the default).
+  /// This is even mentioned in the documentation for said method.
+  bool hasSignedOut = false;
 
   /// Instance of the authentication service for Firebase
   final FirebaseAuth _auth =
@@ -88,7 +97,12 @@ class GoogleAuthService implements AuthService {
 
   @override
   Future<GoogleSignInAccount?> signInSilently() async {
-    final GoogleSignInAccount? account = await _googleSignIn.signInSilently();
+    if (hasSignedOut) {
+      hasSignedOut = false;
+      return null;
+    }
+    final GoogleSignInAccount? account =
+        await _googleSignIn.signInSilently(reAuthenticate: false);
     if (account == null) return null;
     GoogleSignInAuthentication gauth = await account.authentication;
     AuthCredential credential = GoogleAuthProvider.credential(
@@ -104,13 +118,13 @@ class GoogleAuthService implements AuthService {
   /// Resets all the state after closing the firestore instance
   @override
   Future<void> signOut() async {
-    await FirebaseFirestore.instanceFor(
-            app: Firebase.app(EnvModel.FIREBASE_APP_NAME))
-        .terminate();
+    GetIt.I.get<LocationListener>().closeListener();
     await _auth.signOut();
-    await _googleSignIn.signOut();
+    await _googleSignIn.disconnect();
+    hasSignedOut = true;
 
     // ResetSingleton instances to reset any information for the current user
+    //The only one not being reseted is LangSingleton
     GetIt.I.resetLazySingleton<OnboardingController>();
     GetIt.I.resetLazySingleton<ContactsPageController>();
     GetIt.I.resetLazySingleton<ProfileController>();

--- a/wayat/frontend/pubspec.yaml
+++ b/wayat/frontend/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   # Handles logic to import address books contacts
   flutter_contacts: ^1.1.5
   # Google Sign In
-  google_sign_in: ^5.4.0
+  google_sign_in: ^5.4.2
   # Http request for backend
   http: ^0.13.4
   # Decoding Token ID


### PR DESCRIPTION
Fixed that when in web you signed out, the method signInSilently reauthenticated automatically.

Fixed that when you signed out, the Firestore connection terminated and you could not get any data